### PR TITLE
UIFC-415: Migrate react-intl to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-find-finc-metadata-source
 
-## 7.1.0 (IN PROGRESS)
+## 8.0.0 (IN PROGRESS)
+* Migrate react-intl to v7 ([UIFC-415](https://folio-org.atlassian.net/browse/UIFC-415))
 
 ## [7.0.0](https://github.com/folio-org/ui-plugin-find-finc-metadata-source/tree/v7.0.0) (2024-11-04)
 * Use functional components instead of class components ([UIFC-363](https://folio-org.atlassian.net/browse/UIFC-363))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-finc-metadata-source",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Finder plugin for finc metadata sources",
   "repository": "folio-org/ui-plugin-find-finc-metadata-source",
   "publishConfig": {
@@ -22,7 +22,7 @@
     "test:jest": "jest --ci --coverage",
     "lint": "eslint .",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-plugin-find-finc-metadata-source ./translations/ui-plugin-find-finc-metadata-source/compiled"
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",
@@ -34,11 +34,10 @@
     "@folio/stripes-components": "^12.2.3",
     "@folio/stripes-core": "^10.2.2",
     "@folio/stripes-smart-components": "^9.2.2",
-    "@formatjs/cli": "^6.1.3",
     "eslint": "^7.32.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   },
   "dependencies": {
@@ -50,7 +49,7 @@
     "@folio/stripes": "^9.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIFC-415

- update react-intl to v7
- remove @formatjs/cli; stripes-cli has it built-in

Refs [STRIPES-960](https://folio-org.atlassian.net/browse/STRIPES-960)